### PR TITLE
Solving implicit assignment of unexported field issue in cachego.Mongo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@
 Simple interface around cache drivers
 
 ## Installation
+
 Cachego requires Go 1.5 or later.
+
 ```
 go get github.com/fabiorphp/cachego
 ```
 
-If you want to get an specific version, please use the example bellow:
+If you want to get an specific version, please use the example below:
+
 ```
 go get gopkg.in/fabiorphp/cachego.v0
 ```
@@ -26,15 +29,13 @@ package main
 
 import (
     "github.com/fabiorphp/cachego"
-	"github.com/bradfitz/gomemcache/memcache"
+    "github.com/bradfitz/gomemcache/memcache"
 )
 
 var cache cachego.Cache
 
 func init() {
-    cache = &cachego.Memcached{
-        memcached.New("localhost:11211")
-    }
+    cache = cachego.NewMemcached(memcached.New("localhost:11211"))
 }
 ```
 
@@ -45,17 +46,17 @@ package main
 
 import (
     "github.com/fabiorphp/cachego"
-	"gopkg.in/redis.v4"
+    "gopkg.in/redis.v4"
 )
 
 var cache cachego.Cache
 
 func init() {
-	cache = &cachego.Redis{
-	    redis.NewClient(&redis.Options{
+    cache = cachego.NewRedis(
+        redis.NewClient(&redis.Options{
             Addr: ":6379",
-	    }),
-    }
+        }),
+    )
 }
 ```
 
@@ -71,9 +72,9 @@ import (
 var cache cachego.Cache
 
 func init() {
-	cache = &cachego.File{
+    cache = cachego.NewFile(
         "/cache-dir/",
-    }
+    )
 }
 ```
 
@@ -89,7 +90,7 @@ import (
 var cache cachego.Cache
 
 func init() {
-	cache = NewMapCache()
+    cache = NewMap()
 }
 ```
 
@@ -100,17 +101,17 @@ package main
 
 import (
     "github.com/fabiorphp/cachego"
-	"gopkg.in/mgo.v2"
+    "gopkg.in/mgo.v2"
 )
 
 var cache cachego.Cache
 
 func init() {
-	session, _ := mgo.Dial(address)
+    session, _ := mgo.Dial(address)
 
-	cache = &cachego.Mongo{
-		session.DB("cache").C("cache"),
-    }
+    cache = cachego.NewMongo(
+        session.DB("cache").C("cache"),
+    )
 }
 ```
 
@@ -126,32 +127,31 @@ import (
 var cache cachego.Cache
 
 func init() {
-    memacached := &cachego.Memcached{
-        memcached.New("localhost:11211")
-    }
+    memcached := cachego.NewMemcached(
+        memcached.New("localhost:11211"),
+    )
 
-	redis := &cachego.Redis{
-	    redis.NewClient(&redis.Options{
+    redis := cachego.NewRedis(
+        redis.NewClient(&redis.Options{
             Addr: ":6379",
-	    }),
-    }
+        }),
+    )
 
-	file := &cachego.File{
-        "/cache-dir/",
-    }
+    file := cachego.NewFile(
+        "/cache-dir/"
+    )
 
-	cache = &cachego.Chain{
-        []cachego.Cache{
-            cachego.NewMapCache(),
-            memcached,
-            redis,
-            file,
-        },
-    }
+    cache = cachego.NewChain(
+        cachego.NewMap(),
+        memcached,
+        redis,
+        file,
+    )
 }
 ```
 
 ### Usage
+
 ```go
 package main
 
@@ -176,11 +176,10 @@ func main() {
 }
 ```
 
-
 ## Documentation
 
 Read the full documentation at [https://godoc.org/github.com/fabiorphp/cachego](https://godoc.org/github.com/fabiorphp/cachego).
 
 ## License
 
-This project is released under the MIT licence. See [LICENCE](https://github.com/fabiorphp/cachego/blob/master/LICENSE) for more details.
+This project is released under the MIT licence. See [LICENSE](https://github.com/fabiorphp/cachego/blob/master/LICENSE) for more details.

--- a/cache.go
+++ b/cache.go
@@ -1,28 +1,29 @@
 package cachego
 
 import (
-	"time"
+    "time"
 )
 
 type (
-	// Cache is the top-level cache interface
-	Cache interface {
-		// Contains check if a cached key exists
-		Contains(key string) bool
+    // Cache is the top-level cache interface
+    Cache interface {
 
-		// Delete remove the cached key
-		Delete(key string) error
+        // Contains check if a cached key exists
+        Contains(key string) bool
 
-		// Fetch retrieve the cached key value
-		Fetch(key string) (string, error)
+        // Delete remove the cached key
+        Delete(key string) error
 
-		// FetchMulti retrieve multiple cached keys value
-		FetchMulti(keys []string) map[string]string
+        // Fetch retrieve the cached key value
+        Fetch(key string) (string, error)
 
-		// Flush remove all cached keys
-		Flush() error
+        // FetchMulti retrieve multiple cached keys value
+        FetchMulti(keys []string) map[string]string
 
-		// Save cache a value by key
-		Save(key string, value string, lifeTime time.Duration) error
-	}
+        // Flush remove all cached keys
+        Flush() error
+
+        // Save cache a value by key
+        Save(key string, value string, lifeTime time.Duration) error
+    }
 )

--- a/chain.go
+++ b/chain.go
@@ -1,88 +1,93 @@
 package cachego
 
 import (
-	"fmt"
-	"strings"
-	"time"
+    "fmt"
+    "strings"
+    "time"
 )
 
 type (
-	// Chain storage for dealing with multiple cache storage in the same time
-	Chain struct {
-		drivers []Cache
-	}
+    // Chain storage for dealing with multiple cache storage in the same time
+    Chain struct {
+        drivers []Cache
+    }
 )
+
+// NewChain - Create an instance of Chain
+func NewChain(drivers ...Cache) *Chain {
+    return &Chain{drivers}
+}
 
 // Check if cached key exists in one of cache storage
 func (c *Chain) Contains(key string) bool {
-	for _, driver := range c.drivers {
-		if driver.Contains(key) {
-			return true
-		}
-	}
+    for _, driver := range c.drivers {
+        if driver.Contains(key) {
+            return true
+        }
+    }
 
-	return false
+    return false
 }
 
 // Delete the cached key in all cache storages
 func (c *Chain) Delete(key string) error {
-	for _, driver := range c.drivers {
-		if err := driver.Delete(key); err != nil {
-			return err
-		}
-	}
+    for _, driver := range c.drivers {
+        if err := driver.Delete(key); err != nil {
+            return err
+        }
+    }
 
-	return nil
+    return nil
 }
 
 // Retrieves the value of the first cache storage found
 func (c *Chain) Fetch(key string) (string, error) {
 
-	errs := []string{}
+    errs := []string{}
 
-	for _, driver := range c.drivers {
-		if value, err := driver.Fetch(key); err == nil {
-			return value, nil
-		} else {
-			errs = append(errs, err.Error())
-		}
-	}
+    for _, driver := range c.drivers {
+        if value, err := driver.Fetch(key); err == nil {
+            return value, nil
+        } else {
+            errs = append(errs, err.Error())
+        }
+    }
 
-	return "", fmt.Errorf("Key not found in cache chain. Errors: %s", strings.Join(errs, ","))
+    return "", fmt.Errorf("Key not found in cache chain. Errors: %s", strings.Join(errs, ","))
 }
 
 // Retrieve multiple cached value from keys of the first cache storage found
 func (c *Chain) FetchMulti(keys []string) map[string]string {
-	result := make(map[string]string)
+    result := make(map[string]string)
 
-	for _, key := range keys {
-		if value, err := c.Fetch(key); err == nil {
-			result[key] = value
-		}
-	}
+    for _, key := range keys {
+        if value, err := c.Fetch(key); err == nil {
+            result[key] = value
+        }
+    }
 
-	return result
+    return result
 }
 
 // Remove all cached keys of the all cache storages
 func (c *Chain) Flush() error {
-	for _, driver := range c.drivers {
-		if err := driver.Flush(); err != nil {
-			return err
-		}
-	}
+    for _, driver := range c.drivers {
+        if err := driver.Flush(); err != nil {
+            return err
+        }
+    }
 
-	return nil
+    return nil
 }
 
 // Save a value in all cache storages by key
 func (c *Chain) Save(key string, value string, lifeTime time.Duration) error {
 
-	for _, driver := range c.drivers {
-		if err := driver.Save(key, value, lifeTime); err != nil {
-			return err
-		}
-	}
+    for _, driver := range c.drivers {
+        if err := driver.Save(key, value, lifeTime); err != nil {
+            return err
+        }
+    }
 
-	return nil
+    return nil
 }

--- a/chain_test.go
+++ b/chain_test.go
@@ -1,137 +1,121 @@
 package cachego
 
 import (
-	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
+    "github.com/bradfitz/gomemcache/memcache"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/suite"
+    "testing"
+    "time"
 )
 
 type ChainTestSuite struct {
-	suite.Suite
+    suite.Suite
 
-	assert *assert.Assertions
-	cache  Cache
+    assert *assert.Assertions
+    cache  Cache
 }
 
 func (s *ChainTestSuite) SetupTest() {
-	drivers := []Cache{
-		NewMapCache(),
-	}
+    s.cache = NewChain(NewMap())
 
-	s.cache = &Chain{drivers}
-
-	s.assert = assert.New(s.T())
+    s.assert = assert.New(s.T())
 }
 
 func (s *ChainTestSuite) TestSaveThrowErrorWhenOneOfDriverFail() {
-	cache := &Chain{
-		[]Cache{
-			NewMapCache(),
-			&Memcached{
-				memcache.New("127.0.0.1:22222"),
-			},
-		},
-	}
+    cache := NewChain(
+        NewMap(),
+        NewMemcached(memcache.New("127.0.0.1:22222")),
+    )
 
-	s.assert.Error(cache.Save("foo", "bar", 0))
+    s.assert.Error(cache.Save("foo", "bar", 0))
 }
 
 func (s *ChainTestSuite) TestSave() {
-	s.assert.Nil(s.cache.Save("foo", "bar", 0))
+    s.assert.Nil(s.cache.Save("foo", "bar", 0))
 }
 
 func (s *ChainTestSuite) TestFetchThrowErrorWhenExpired() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 1*time.Second)
+    s.cache.Save(key, value, 1*time.Second)
 
-	time.Sleep(1 * time.Second)
+    time.Sleep(1 * time.Second)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Regexp("^Key not found in cache chain", err)
-	s.assert.Empty(result)
+    s.assert.Regexp("^Key not found in cache chain", err)
+    s.assert.Empty(result)
 }
 
 func (s *ChainTestSuite) TestFetch() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *ChainTestSuite) TestContains() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.True(s.cache.Contains("foo"))
-	s.assert.False(s.cache.Contains("bar"))
+    s.assert.True(s.cache.Contains("foo"))
+    s.assert.False(s.cache.Contains("bar"))
 }
 
 func (s *ChainTestSuite) TestDeleteThrowErrorWhenOneOfDriverFail() {
-	cache := &Chain{
-		[]Cache{
-			NewMapCache(),
-			&Memcached{
-				memcache.New("127.0.0.1:22222"),
-			},
-		},
-	}
+    cache := NewChain(
+        NewMap(),
+        NewMemcached(memcache.New("127.0.0.1:22222")),
+    )
 
-	s.assert.Error(cache.Delete("foo"))
+    s.assert.Error(cache.Delete("foo"))
 }
 
 func (s *ChainTestSuite) TestDelete() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Delete("foo"))
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Delete("foo"))
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *ChainTestSuite) TestFlushThrowErrorWhenOneOfDriverFail() {
-	cache := &Chain{
-		[]Cache{
-			NewMapCache(),
-			&Memcached{
-				memcache.New("127.0.0.1:22222"),
-			},
-		},
-	}
+    cache := NewChain(
+        NewMap(),
+        NewMemcached(memcache.New("127.0.0.1:22222")),
+    )
 
-	s.assert.Error(cache.Flush())
+    s.assert.Error(cache.Flush())
 }
 
 func (s *ChainTestSuite) TestFlush() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Flush())
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Flush())
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *ChainTestSuite) TestFetchMulti() {
-	s.cache.Save("foo", "bar", 0)
-	s.cache.Save("john", "doe", 0)
+    s.cache.Save("foo", "bar", 0)
+    s.cache.Save("john", "doe", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "john"})
+    result := s.cache.FetchMulti([]string{"foo", "john"})
 
-	s.assert.Len(result, 2)
+    s.assert.Len(result, 2)
 }
 
 func (s *ChainTestSuite) TestFetchMultiWhenOnlyOneOfKeysExists() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "alice"})
+    result := s.cache.FetchMulti([]string{"foo", "alice"})
 
-	s.assert.Len(result, 1)
+    s.assert.Len(result, 1)
 }
 
 func TestChainRunSuite(t *testing.T) {
-	suite.Run(t, new(ChainTestSuite))
+    suite.Run(t, new(ChainTestSuite))
 }

--- a/doc.go
+++ b/doc.go
@@ -11,9 +11,9 @@
 //
 //    func main() {
 //
-//      cache := &cachego.Memcached{
+//      cache := cachego.NewMemcached(
 //          memcached.New("localhost:11211"),
-//      }
+//      )
 //
 //      cache.Save("foo", "bar")
 //

--- a/file.go
+++ b/file.go
@@ -1,167 +1,172 @@
 package cachego
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	errors "github.com/pkg/errors"
-	"io/ioutil"
-	"os"
-	"path/filepath"
-	"time"
+    "crypto/sha256"
+    "encoding/hex"
+    "encoding/json"
+    errors "github.com/pkg/errors"
+    "io/ioutil"
+    "os"
+    "path/filepath"
+    "time"
 )
 
 type (
-	// File store for caching data
-	File struct {
-		dir string
-	}
+    // File store for caching data
+    File struct {
+        dir string
+    }
 
-	// File content it's a structure of cached value
-	FileContent struct {
-		Duration int64  `json:"duration"`
-		Data     string `json:"data, omitempty"`
-	}
+    // File content it's a structure of cached value
+    FileContent struct {
+        Duration int64  `json:"duration"`
+        Data     string `json:"data, omitempty"`
+    }
 )
 
+// NewFile - Create an instance of File
+func NewFile(dir string) *File {
+    return &File{dir}
+}
+
 func (f *File) createName(key string) string {
-	h := sha256.New()
-	h.Write([]byte(key))
-	hash := hex.EncodeToString(h.Sum(nil))
+    h := sha256.New()
+    h.Write([]byte(key))
+    hash := hex.EncodeToString(h.Sum(nil))
 
-	filename := hash + ".cachego"
+    filename := hash + ".cachego"
 
-	filePath := filepath.Join(f.dir, filename)
+    filePath := filepath.Join(f.dir, filename)
 
-	return filePath
+    return filePath
 }
 
 func (f *File) read(key string) (*FileContent, error) {
-	value, err := ioutil.ReadFile(
-		f.createName(key),
-	)
+    value, err := ioutil.ReadFile(
+        f.createName(key),
+    )
 
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to open")
-	}
+    if err != nil {
+        return nil, errors.Wrap(err, "Unable to open")
+    }
 
-	content := &FileContent{}
+    content := &FileContent{}
 
-	err = json.Unmarshal(value, content)
+    err = json.Unmarshal(value, content)
 
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to decode json data")
-	}
+    if err != nil {
+        return nil, errors.Wrap(err, "Unable to decode json data")
+    }
 
-	if content.Duration == 0 {
-		return content, nil
-	}
+    if content.Duration == 0 {
+        return content, nil
+    }
 
-	if content.Duration <= time.Now().Unix() {
-		f.Delete(key)
-		return nil, errors.New("Cache expired")
-	}
+    if content.Duration <= time.Now().Unix() {
+        f.Delete(key)
+        return nil, errors.New("Cache expired")
+    }
 
-	return content, nil
+    return content, nil
 }
 
 // Check if cached key exists in File storage
 func (f *File) Contains(key string) bool {
 
-	if _, err := f.read(key); err != nil {
-		return false
-	}
+    if _, err := f.read(key); err != nil {
+        return false
+    }
 
-	return true
+    return true
 }
 
 // Delete the cached key from File storage
 func (f *File) Delete(key string) error {
-	_, err := os.Stat(
-		f.createName(key),
-	)
+    _, err := os.Stat(
+        f.createName(key),
+    )
 
-	if err != nil && os.IsNotExist(err) {
-		return nil
-	}
+    if err != nil && os.IsNotExist(err) {
+        return nil
+    }
 
-	err = os.Remove(
-		f.createName(key),
-	)
+    err = os.Remove(
+        f.createName(key),
+    )
 
-	if err != nil {
-		return errors.Wrap(err, "Unable to delete")
-	}
+    if err != nil {
+        return errors.Wrap(err, "Unable to delete")
+    }
 
-	return nil
+    return nil
 }
 
 // Retrieve the cached value from key of the File storage
 func (f *File) Fetch(key string) (string, error) {
-	content, err := f.read(key)
+    content, err := f.read(key)
 
-	if err != nil {
-		return "", err
-	}
+    if err != nil {
+        return "", err
+    }
 
-	return content.Data, nil
+    return content.Data, nil
 }
 
 // Retrieve multiple cached value from keys of the File storage
 func (f *File) FetchMulti(keys []string) map[string]string {
-	result := make(map[string]string)
+    result := make(map[string]string)
 
-	for _, key := range keys {
-		if value, err := f.Fetch(key); err == nil {
-			result[key] = value
-		}
-	}
+    for _, key := range keys {
+        if value, err := f.Fetch(key); err == nil {
+            result[key] = value
+        }
+    }
 
-	return result
+    return result
 }
 
 // Remove all cached keys in File storage
 func (f *File) Flush() error {
-	dir, err := os.Open(f.dir)
+    dir, err := os.Open(f.dir)
 
-	if err != nil {
-		return errors.Wrap(err, "Unable to open file")
-	}
+    if err != nil {
+        return errors.Wrap(err, "Unable to open file")
+    }
 
-	defer dir.Close()
+    defer dir.Close()
 
-	names, _ := dir.Readdirnames(-1)
+    names, _ := dir.Readdirnames(-1)
 
-	for _, name := range names {
-		os.Remove(filepath.Join(f.dir, name))
-	}
+    for _, name := range names {
+        os.Remove(filepath.Join(f.dir, name))
+    }
 
-	return nil
+    return nil
 }
 
 // Save a value in File storage by key
 func (f *File) Save(key string, value string, lifeTime time.Duration) error {
 
-	duration := int64(0)
+    duration := int64(0)
 
-	if lifeTime > 0 {
-		duration = time.Now().Unix() + int64(lifeTime.Seconds())
-	}
+    if lifeTime > 0 {
+        duration = time.Now().Unix() + int64(lifeTime.Seconds())
+    }
 
-	content := &FileContent{
-		duration,
-		value,
-	}
+    content := &FileContent{
+        duration,
+        value,
+    }
 
-	data, err := json.Marshal(content)
+    data, err := json.Marshal(content)
 
-	if err != nil {
-		return errors.Wrap(err, "Unable to encode json data")
-	}
+    if err != nil {
+        return errors.Wrap(err, "Unable to encode json data")
+    }
 
-	if err := ioutil.WriteFile(f.createName(key), data, 0666); err != nil {
-		return errors.Wrap(err, "Unable to save")
-	}
+    if err := ioutil.WriteFile(f.createName(key), data, 0666); err != nil {
+        return errors.Wrap(err, "Unable to save")
+    }
 
-	return nil
+    return nil
 }

--- a/file_test.go
+++ b/file_test.go
@@ -1,141 +1,141 @@
 package cachego
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"os"
-	"testing"
-	"time"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/suite"
+    "os"
+    "testing"
+    "time"
 )
 
 type FileTestSuite struct {
-	suite.Suite
+    suite.Suite
 
-	assert *assert.Assertions
-	cache  Cache
+    assert *assert.Assertions
+    cache  Cache
 }
 
 func (s *FileTestSuite) SetupTest() {
-	directory := "./cache-dir/"
+    directory := "./cache-dir/"
 
-	os.Mkdir(directory, 0777)
+    os.Mkdir(directory, 0777)
 
-	s.cache = &File{directory}
-	s.assert = assert.New(s.T())
+    s.cache = NewFile(directory)
+    s.assert = assert.New(s.T())
 }
 
 func (s *FileTestSuite) TestSaveThrowError() {
-	cache := &File{"./test/"}
+    cache := NewFile("./test/")
 
-	s.assert.Regexp("^Unable to save", cache.Save("foo", "bar", 0))
+    s.assert.Regexp("^Unable to save", cache.Save("foo", "bar", 0))
 }
 
 func (s *FileTestSuite) TestSave() {
-	s.assert.Nil(s.cache.Save("foo", "bar", 0))
+    s.assert.Nil(s.cache.Save("foo", "bar", 0))
 }
 
 func (s *FileTestSuite) TestFetchThrowError() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	cache := &File{"./test/"}
+    cache := NewFile("./test/")
 
-	result, err := cache.Fetch(key)
+    result, err := cache.Fetch(key)
 
-	s.assert.Regexp("^Unable to open", err)
-	s.assert.Empty(result)
+    s.assert.Regexp("^Unable to open", err)
+    s.assert.Empty(result)
 }
 
 func (s *FileTestSuite) TestFetchThrowErrorWhenExpired() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 1*time.Second)
+    s.cache.Save(key, value, 1*time.Second)
 
-	time.Sleep(1 * time.Second)
+    time.Sleep(1 * time.Second)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.EqualError(err, "Cache expired")
-	s.assert.Empty(result)
+    s.assert.EqualError(err, "Cache expired")
+    s.assert.Empty(result)
 }
 
 func (s *FileTestSuite) TestFetch() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
-	result, err := s.cache.Fetch(key)
+    s.cache.Save(key, value, 0)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *FileTestSuite) TestFetchLongCacheDuration() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 10*time.Second)
-	result, err := s.cache.Fetch(key)
+    s.cache.Save(key, value, 10*time.Second)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *FileTestSuite) TestContains() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.True(s.cache.Contains("foo"))
-	s.assert.False(s.cache.Contains("bar"))
+    s.assert.True(s.cache.Contains("foo"))
+    s.assert.False(s.cache.Contains("bar"))
 }
 
 func (s *FileTestSuite) TestDelete() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Delete("foo"))
-	s.assert.False(s.cache.Contains("foo"))
-	s.assert.Nil(s.cache.Delete("bar"))
+    s.assert.Nil(s.cache.Delete("foo"))
+    s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Delete("bar"))
 }
 
 func (s *FileTestSuite) TestFlushReturnFalseWhenThrowError() {
-	cache := &File{"./test/"}
+    cache := NewFile("./test/")
 
-	s.assert.Error(cache.Flush(), "OK")
+    s.assert.Error(cache.Flush(), "OK")
 }
 
 func (s *FileTestSuite) TestFlush() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Flush())
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Flush())
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *FileTestSuite) TestFetchMultiReturnNoItemsWhenThrowError() {
-	cache := &File{"./test/"}
-	result := cache.FetchMulti([]string{"foo"})
+    cache := NewFile("./test/")
+    result := cache.FetchMulti([]string{"foo"})
 
-	s.assert.Len(result, 0)
+    s.assert.Len(result, 0)
 }
 
 func (s *FileTestSuite) TestFetchMulti() {
-	s.cache.Save("foo", "bar", 0)
-	s.cache.Save("john", "doe", 0)
+    s.cache.Save("foo", "bar", 0)
+    s.cache.Save("john", "doe", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "john"})
+    result := s.cache.FetchMulti([]string{"foo", "john"})
 
-	s.assert.Len(result, 2)
+    s.assert.Len(result, 2)
 }
 
 func (s *FileTestSuite) TestFetchMultiWhenOnlyOneOfKeysExists() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "alice"})
+    result := s.cache.FetchMulti([]string{"foo", "alice"})
 
-	s.assert.Len(result, 1)
+    s.assert.Len(result, 1)
 }
 
 func TestFileRunSuite(t *testing.T) {
-	suite.Run(t, new(FileTestSuite))
+    suite.Run(t, new(FileTestSuite))
 }

--- a/map.go
+++ b/map.go
@@ -1,104 +1,104 @@
 package cachego
 
 import (
-	"errors"
-	"time"
+    "errors"
+    "time"
 )
 
 type (
-	MapItem struct {
-		data     string
-		duration int64
-	}
+    MapItem struct {
+        data     string
+        duration int64
+    }
 
-	// Map store the data in memory without external server
-	Map struct {
-		storage map[string]*MapItem
-	}
+    // Map store the data in memory without external server
+    Map struct {
+        storage map[string]*MapItem
+    }
 )
 
 // Create an instance of Map storage
-func NewMapCache() *Map {
-	storage := make(map[string]*MapItem)
+func NewMap() *Map {
+    storage := make(map[string]*MapItem)
 
-	return &Map{storage}
+    return &Map{storage}
 }
 
 func (m *Map) read(key string) (*MapItem, error) {
-	item, ok := m.storage[key]
+    item, ok := m.storage[key]
 
-	if !ok {
-		return nil, errors.New("Key not found")
-	}
+    if !ok {
+        return nil, errors.New("Key not found")
+    }
 
-	if item.duration == 0 {
-		return item, nil
-	}
+    if item.duration == 0 {
+        return item, nil
+    }
 
-	if item.duration <= time.Now().Unix() {
-		m.Delete(key)
-		return nil, errors.New("Cache expired")
-	}
+    if item.duration <= time.Now().Unix() {
+        m.Delete(key)
+        return nil, errors.New("Cache expired")
+    }
 
-	return item, nil
+    return item, nil
 }
 
 // Check if cached key exists in Map storage
 func (m *Map) Contains(key string) bool {
-	if _, err := m.Fetch(key); err != nil {
-		return false
-	}
+    if _, err := m.Fetch(key); err != nil {
+        return false
+    }
 
-	return true
+    return true
 }
 
 // Delete the cached key from Map storage
 func (m *Map) Delete(key string) error {
-	delete(m.storage, key)
-	return nil
+    delete(m.storage, key)
+    return nil
 }
 
 // Retrieve the cached value from key of the Map storage
 func (m *Map) Fetch(key string) (string, error) {
-	item, err := m.read(key)
+    item, err := m.read(key)
 
-	if err != nil {
-		return "", err
-	}
+    if err != nil {
+        return "", err
+    }
 
-	return item.data, nil
+    return item.data, nil
 }
 
 // Retrieve multiple cached value from keys of the Map storage
 func (m *Map) FetchMulti(keys []string) map[string]string {
-	result := make(map[string]string)
+    result := make(map[string]string)
 
-	for _, key := range keys {
-		if value, err := m.Fetch(key); err == nil {
-			result[key] = value
-		}
-	}
+    for _, key := range keys {
+        if value, err := m.Fetch(key); err == nil {
+            result[key] = value
+        }
+    }
 
-	return result
+    return result
 }
 
 // Remove all cached keys in Map storage
 func (m *Map) Flush() error {
-	m.storage = make(map[string]*MapItem)
-	return nil
+    m.storage = make(map[string]*MapItem)
+    return nil
 }
 
 // Save a value in Map storage by key
 func (m *Map) Save(key string, value string, lifeTime time.Duration) error {
-	duration := int64(0)
+    duration := int64(0)
 
-	if lifeTime > 0 {
-		duration = time.Now().Unix() + int64(lifeTime.Seconds())
-	}
+    if lifeTime > 0 {
+        duration = time.Now().Unix() + int64(lifeTime.Seconds())
+    }
 
-	item := &MapItem{value, duration}
+    item := &MapItem{value, duration}
 
-	m.storage[key] = item
+    m.storage[key] = item
 
-	return nil
+    return nil
 }

--- a/map_test.go
+++ b/map_test.go
@@ -1,104 +1,104 @@
 package cachego
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"testing"
-	"time"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/suite"
+    "testing"
+    "time"
 )
 
 type MapTestSuite struct {
-	suite.Suite
+    suite.Suite
 
-	assert *assert.Assertions
-	cache  Cache
+    assert *assert.Assertions
+    cache  Cache
 }
 
 func (s *MapTestSuite) SetupTest() {
-	s.cache = NewMapCache()
+    s.cache = NewMap()
 
-	s.assert = assert.New(s.T())
+    s.assert = assert.New(s.T())
 }
 
 func (s *MapTestSuite) TestSave() {
-	s.assert.Nil(s.cache.Save("foo", "bar", 0))
+    s.assert.Nil(s.cache.Save("foo", "bar", 0))
 }
 
 func (s *MapTestSuite) TestFetchThrowErrorWhenExpired() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 1*time.Second)
+    s.cache.Save(key, value, 1*time.Second)
 
-	time.Sleep(1 * time.Second)
+    time.Sleep(1 * time.Second)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.EqualError(err, "Cache expired")
-	s.assert.Empty(result)
+    s.assert.EqualError(err, "Cache expired")
+    s.assert.Empty(result)
 }
 
 func (s *MapTestSuite) TestFetch() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *MapTestSuite) TestFetchLongCacheDuration() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 10*time.Second)
-	result, err := s.cache.Fetch(key)
+    s.cache.Save(key, value, 10*time.Second)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *MapTestSuite) TestContains() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.True(s.cache.Contains("foo"))
-	s.assert.False(s.cache.Contains("bar"))
+    s.assert.True(s.cache.Contains("foo"))
+    s.assert.False(s.cache.Contains("bar"))
 }
 
 func (s *MapTestSuite) TestDelete() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Delete("foo"))
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Delete("foo"))
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *MapTestSuite) TestFlush() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Flush())
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Flush())
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *MapTestSuite) TestFetchMulti() {
-	s.cache.Save("foo", "bar", 0)
-	s.cache.Save("john", "doe", 0)
+    s.cache.Save("foo", "bar", 0)
+    s.cache.Save("john", "doe", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "john"})
+    result := s.cache.FetchMulti([]string{"foo", "john"})
 
-	s.assert.Len(result, 2)
+    s.assert.Len(result, 2)
 }
 
 func (s *MapTestSuite) TestFetchMultiWhenOnlyOneOfKeysExists() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "alice"})
+    result := s.cache.FetchMulti([]string{"foo", "alice"})
 
-	s.assert.Len(result, 1)
+    s.assert.Len(result, 1)
 }
 
 func TestMapRunSuite(t *testing.T) {
-	suite.Run(t, new(MapTestSuite))
+    suite.Run(t, new(MapTestSuite))
 }

--- a/memcached.go
+++ b/memcached.go
@@ -1,75 +1,80 @@
 package cachego
 
 import (
-	"github.com/bradfitz/gomemcache/memcache"
-	"time"
+    "github.com/bradfitz/gomemcache/memcache"
+    "time"
 )
 
 type (
-	// Memcached it's a wrap around the memcached driver
-	Memcached struct {
-		driver *memcache.Client
-	}
+    // Memcached it's a wrap around the memcached driver
+    Memcached struct {
+        driver *memcache.Client
+    }
 )
+
+// NewMemcached - Create an instance of Memcached
+func NewMemcached(driver *memcache.Client) *Memcached {
+    return &Memcached{driver}
+}
 
 // Check if cached key exists in Memcached storage
 func (m *Memcached) Contains(key string) bool {
-	if _, err := m.Fetch(key); err != nil {
-		return false
-	}
+    if _, err := m.Fetch(key); err != nil {
+        return false
+    }
 
-	return true
+    return true
 }
 
 // Delete the cached key from Memcached storage
 func (m *Memcached) Delete(key string) error {
-	return m.driver.Delete(key)
+    return m.driver.Delete(key)
 }
 
 // Retrieve the cached value from key of the Memcached storage
 func (m *Memcached) Fetch(key string) (string, error) {
-	item, err := m.driver.Get(key)
+    item, err := m.driver.Get(key)
 
-	if err != nil {
-		return "", err
-	}
+    if err != nil {
+        return "", err
+    }
 
-	value := string(item.Value[:])
+    value := string(item.Value[:])
 
-	return value, nil
+    return value, nil
 }
 
 // Retrieve multiple cached value from keys of the Memcached storage
 func (m *Memcached) FetchMulti(keys []string) map[string]string {
-	result := make(map[string]string)
+    result := make(map[string]string)
 
-	items, err := m.driver.GetMulti(keys)
+    items, err := m.driver.GetMulti(keys)
 
-	if err != nil {
-		return result
-	}
+    if err != nil {
+        return result
+    }
 
-	for _, i := range items {
-		result[i.Key] = string(i.Value[:])
-	}
+    for _, i := range items {
+        result[i.Key] = string(i.Value[:])
+    }
 
-	return result
+    return result
 }
 
 // Remove all cached keys in Memcached storage
 func (m *Memcached) Flush() error {
-	return m.driver.FlushAll()
+    return m.driver.FlushAll()
 }
 
 // Save a value in Memcached storage by key
 func (m *Memcached) Save(key string, value string, lifeTime time.Duration) error {
-	err := m.driver.Set(
-		&memcache.Item{
-			Key:        key,
-			Value:      []byte(value),
-			Expiration: int32(lifeTime.Seconds()),
-		},
-	)
+    err := m.driver.Set(
+        &memcache.Item{
+            Key:        key,
+            Value:      []byte(value),
+            Expiration: int32(lifeTime.Seconds()),
+        },
+    )
 
-	return err
+    return err
 }

--- a/memcached_test.go
+++ b/memcached_test.go
@@ -1,132 +1,130 @@
 package cachego
 
 import (
-	"github.com/bradfitz/gomemcache/memcache"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"net"
-	"testing"
+    "github.com/bradfitz/gomemcache/memcache"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/suite"
+    "net"
+    "testing"
 )
 
 type MemcachedTestSuite struct {
-	suite.Suite
+    suite.Suite
 
-	assert *assert.Assertions
-	cache  Cache
+    assert *assert.Assertions
+    cache  Cache
 }
 
 func (s *MemcachedTestSuite) SetupTest() {
-	address := "localhost:11211"
-	conn := memcache.New(address)
+    address := "localhost:11211"
+    conn := memcache.New(address)
 
-	if _, err := net.Dial("tcp", address); err != nil {
-		s.T().Skip()
-	}
+    if _, err := net.Dial("tcp", address); err != nil {
+        s.T().Skip()
+    }
 
-	s.cache = &Memcached{conn}
+    s.cache = NewMemcached(conn)
 
-	s.assert = assert.New(s.T())
+    s.assert = assert.New(s.T())
 }
 
 func (s *MemcachedTestSuite) TestSaveThrowError() {
-	memcached := memcache.New("127.0.0.1:22222")
+    memcached := memcache.New("127.0.0.1:22222")
 
-	cache := &Memcached{memcached}
+    cache := NewMemcached(memcached)
 
-	s.assert.Error(cache.Save("foo", "bar", 0))
+    s.assert.Error(cache.Save("foo", "bar", 0))
 }
 
 func (s *MemcachedTestSuite) TestSave() {
-	s.assert.Nil(s.cache.Save("foo", "bar", 0))
+    s.assert.Nil(s.cache.Save("foo", "bar", 0))
 }
 
 func (s *MemcachedTestSuite) TestFetchThrowError() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	memcached := memcache.New("127.0.0.1:22222")
-	cache := &Memcached{memcached}
+    memcached := memcache.New("127.0.0.1:22222")
+    cache := NewMemcached(memcached)
 
-	result, err := cache.Fetch(key)
+    result, err := cache.Fetch(key)
 
-	s.assert.Error(err)
-	s.assert.Empty(result)
+    s.assert.Error(err)
+    s.assert.Empty(result)
 }
 
 func (s *MemcachedTestSuite) TestFetch() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *MemcachedTestSuite) TestContains() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.True(s.cache.Contains("foo"))
-	s.assert.False(s.cache.Contains("bar"))
+    s.assert.True(s.cache.Contains("foo"))
+    s.assert.False(s.cache.Contains("bar"))
 }
 
 func (s *MemcachedTestSuite) TestDeleteThrowError() {
-	s.assert.Error(s.cache.Delete("bar"))
+    s.assert.Error(s.cache.Delete("bar"))
 }
 
 func (s *MemcachedTestSuite) TestDelete() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Delete("foo"))
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Delete("foo"))
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *MemcachedTestSuite) TestFlushThrowError() {
-	memcached := memcache.New("127.0.0.1:22222")
+    memcached := memcache.New("127.0.0.1:22222")
 
-	cache := &Memcached{memcached}
+    cache := NewMemcached(memcached)
 
-	s.assert.Error(cache.Flush())
+    s.assert.Error(cache.Flush())
 }
 
 func (s *MemcachedTestSuite) TestFlush() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Flush())
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Flush())
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *MemcachedTestSuite) TestFetchMultiReturnNoItemsWhenThrowError() {
-	cache := &Memcached{
-		memcache.New("127.0.0.1:22222"),
-	}
+    cache := NewMemcached(memcache.New("127.0.0.1:22222"))
 
-	result := cache.FetchMulti([]string{"foo"})
+    result := cache.FetchMulti([]string{"foo"})
 
-	s.assert.Len(result, 0)
+    s.assert.Len(result, 0)
 }
 
 func (s *MemcachedTestSuite) TestFetchMulti() {
-	s.cache.Save("foo", "bar", 0)
-	s.cache.Save("john", "doe", 0)
+    s.cache.Save("foo", "bar", 0)
+    s.cache.Save("john", "doe", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "john"})
+    result := s.cache.FetchMulti([]string{"foo", "john"})
 
-	s.assert.Len(result, 2)
+    s.assert.Len(result, 2)
 }
 
 func (s *MemcachedTestSuite) TestFetchMultiWhenOnlyOneOfKeysExists() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "alice"})
+    result := s.cache.FetchMulti([]string{"foo", "alice"})
 
-	s.assert.Len(result, 1)
+    s.assert.Len(result, 1)
 }
 
 func TestMemcachedRunSuite(t *testing.T) {
-	suite.Run(t, new(MemcachedTestSuite))
+    suite.Run(t, new(MemcachedTestSuite))
 }

--- a/mongo.go
+++ b/mongo.go
@@ -1,101 +1,106 @@
 package cachego
 
 import (
-	"errors"
-	"gopkg.in/mgo.v2"
-	"gopkg.in/mgo.v2/bson"
-	"time"
+    "errors"
+    "gopkg.in/mgo.v2"
+    "gopkg.in/mgo.v2/bson"
+    "time"
 )
 
 type (
-	// Mongo it's a wrap around the mgo driver
-	Mongo struct {
-		collection *mgo.Collection
-	}
+    // Mongo it's a wrap around the mgo driver
+    Mongo struct {
+        collection *mgo.Collection
+    }
 
-	// MongoContent it's a bson structure of cached value
-	MongoContent struct {
-		Duration int64
-		Key      string `bson:"_id"`
-		Value    string
-	}
+    // MongoContent it's a bson structure of cached value
+    MongoContent struct {
+        Duration int64
+        Key      string `bson:"_id"`
+        Value    string
+    }
 )
+
+// NewMongo - Create an instance of Mongo
+func NewMongo(collection *mgo.Collection) *Mongo {
+    return &Mongo{collection}
+}
 
 // Check if cached key exists in Mongo storage
 func (m *Mongo) Contains(key string) bool {
-	if _, err := m.Fetch(key); err != nil {
-		return false
-	}
+    if _, err := m.Fetch(key); err != nil {
+        return false
+    }
 
-	return true
+    return true
 }
 
 // Delete the cached key from Mongo storage
 func (m *Mongo) Delete(key string) error {
-	return m.collection.Remove(bson.M{"_id": key})
+    return m.collection.Remove(bson.M{"_id": key})
 }
 
 // Retrieve the cached value from key of the Mongo storage
 func (m *Mongo) Fetch(key string) (string, error) {
-	content := &MongoContent{}
+    content := &MongoContent{}
 
-	err := m.collection.Find(bson.M{"_id": key}).One(content)
+    err := m.collection.Find(bson.M{"_id": key}).One(content)
 
-	if err != nil {
-		return "", err
-	}
+    if err != nil {
+        return "", err
+    }
 
-	if content.Duration == 0 {
-		return content.Value, nil
-	}
+    if content.Duration == 0 {
+        return content.Value, nil
+    }
 
-	if content.Duration <= time.Now().Unix() {
-		m.Delete(key)
-		return "", errors.New("Cache expired")
-	}
+    if content.Duration <= time.Now().Unix() {
+        m.Delete(key)
+        return "", errors.New("Cache expired")
+    }
 
-	return content.Value, nil
+    return content.Value, nil
 }
 
 // Retrieve multiple cached value from keys of the Mongo storage
 func (m *Mongo) FetchMulti(keys []string) map[string]string {
-	result := make(map[string]string)
+    result := make(map[string]string)
 
-	iter := m.collection.Find(bson.M{"_id": bson.M{"$in": keys}}).Iter()
+    iter := m.collection.Find(bson.M{"_id": bson.M{"$in": keys}}).Iter()
 
-	content := &MongoContent{}
+    content := &MongoContent{}
 
-	for iter.Next(content) {
-		result[content.Key] = content.Value
-	}
+    for iter.Next(content) {
+        result[content.Key] = content.Value
+    }
 
-	return result
+    return result
 }
 
 // Remove all cached keys in Mongo storage
 func (m *Mongo) Flush() error {
-	_, err := m.collection.RemoveAll(bson.M{})
+    _, err := m.collection.RemoveAll(bson.M{})
 
-	return err
+    return err
 }
 
 // Save a value in Mongo storage by key
 func (m *Mongo) Save(key string, value string, lifeTime time.Duration) error {
-	duration := int64(0)
+    duration := int64(0)
 
-	if lifeTime > 0 {
-		duration = time.Now().Unix() + int64(lifeTime.Seconds())
-	}
+    if lifeTime > 0 {
+        duration = time.Now().Unix() + int64(lifeTime.Seconds())
+    }
 
-	content := &MongoContent{
-		duration,
-		key,
-		value,
-	}
+    content := &MongoContent{
+        duration,
+        key,
+        value,
+    }
 
-	if _, err := m.collection.Upsert(bson.M{"_id": key}, content); err != nil {
-		return err
-	}
+    if _, err := m.collection.Upsert(bson.M{"_id": key}, content); err != nil {
+        return err
+    }
 
-	return nil
+    return nil
 }

--- a/mongo_test.go
+++ b/mongo_test.go
@@ -1,132 +1,130 @@
 package cachego
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"gopkg.in/mgo.v2"
-	"net"
-	"testing"
-	"time"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/suite"
+    "gopkg.in/mgo.v2"
+    "net"
+    "testing"
+    "time"
 )
 
 type MongoTestSuite struct {
-	suite.Suite
+    suite.Suite
 
-	assert  *assert.Assertions
-	cache   Cache
-	session *mgo.Session
+    assert  *assert.Assertions
+    cache   Cache
+    session *mgo.Session
 }
 
 func (s *MongoTestSuite) SetupTest() {
-	address := "localhost:27017"
+    address := "localhost:27017"
 
-	if _, err := net.Dial("tcp", address); err != nil {
-		s.T().Skip()
-	}
+    if _, err := net.Dial("tcp", address); err != nil {
+        s.T().Skip()
+    }
 
-	session, err := mgo.Dial(address)
+    session, err := mgo.Dial(address)
 
-	if err != nil {
-		s.T().Skip()
-	}
+    if err != nil {
+        s.T().Skip()
+    }
 
-	s.cache = &Mongo{
-		session.DB("cache").C("cache"),
-	}
+    s.cache = NewMongo(session.DB("cache").C("cache"))
 
-	s.assert = assert.New(s.T())
+    s.assert = assert.New(s.T())
 }
 
 func (s *MongoTestSuite) TestSave() {
-	s.assert.Nil(s.cache.Save("foo", "bar", 10))
+    s.assert.Nil(s.cache.Save("foo", "bar", 10))
 }
 
 func (s *MongoTestSuite) TestFetchThrowError() {
-	result, err := s.cache.Fetch("bar")
+    result, err := s.cache.Fetch("bar")
 
-	s.assert.Error(err)
-	s.assert.Empty(result)
+    s.assert.Error(err)
+    s.assert.Empty(result)
 }
 
 func (s *MongoTestSuite) TestFetchThrowErrorWhenExpired() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 1*time.Second)
+    s.cache.Save(key, value, 1*time.Second)
 
-	time.Sleep(1 * time.Second)
+    time.Sleep(1 * time.Second)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.EqualError(err, "Cache expired")
-	s.assert.Empty(result)
+    s.assert.EqualError(err, "Cache expired")
+    s.assert.Empty(result)
 }
 
 func (s *MongoTestSuite) TestFetch() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *MongoTestSuite) TestFetchLongCacheDuration() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 10*time.Second)
-	result, err := s.cache.Fetch(key)
+    s.cache.Save(key, value, 10*time.Second)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *MongoTestSuite) TestContains() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.True(s.cache.Contains("foo"))
-	s.assert.False(s.cache.Contains("bar"))
+    s.assert.True(s.cache.Contains("foo"))
+    s.assert.False(s.cache.Contains("bar"))
 }
 
 func (s *MongoTestSuite) TestDeleteThrowError() {
-	s.assert.Error(s.cache.Delete("bar"))
+    s.assert.Error(s.cache.Delete("bar"))
 }
 
 func (s *MongoTestSuite) TestDelete() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Delete("foo"))
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Delete("foo"))
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *MongoTestSuite) TestFlush() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Flush())
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Flush())
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *MongoTestSuite) TestFetchMulti() {
-	s.cache.Save("foo", "bar", 0)
-	s.cache.Save("john", "doe", 0)
+    s.cache.Save("foo", "bar", 0)
+    s.cache.Save("john", "doe", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "john"})
+    result := s.cache.FetchMulti([]string{"foo", "john"})
 
-	s.assert.Len(result, 2)
+    s.assert.Len(result, 2)
 }
 
 func (s *MongoTestSuite) TestFetchMultiWhenOnlyOneOfKeysExists() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "alice"})
+    result := s.cache.FetchMulti([]string{"foo", "alice"})
 
-	s.assert.Len(result, 1)
+    s.assert.Len(result, 1)
 }
 
 func TestMongoRunSuite(t *testing.T) {
-	suite.Run(t, new(MongoTestSuite))
+    suite.Run(t, new(MongoTestSuite))
 }

--- a/redis.go
+++ b/redis.go
@@ -1,69 +1,74 @@
 package cachego
 
 import (
-	"gopkg.in/redis.v4"
-	"time"
+    "gopkg.in/redis.v4"
+    "time"
 )
 
 type (
-	// Redis it's a wrap around the redis driver
-	Redis struct {
-		driver *redis.Client
-	}
+    // Redis it's a wrap around the redis driver
+    Redis struct {
+        driver *redis.Client
+    }
 )
+
+// NewRedis - Create an instance of Redis
+func NewRedis(driver *redis.Client) *Redis {
+    return &Redis{driver}
+}
 
 // Check if cached key exists in Redis storage
 func (r *Redis) Contains(key string) bool {
-	status, err := r.driver.Exists(key).Result()
+    status, err := r.driver.Exists(key).Result()
 
-	if err != nil {
-		return false
-	}
+    if err != nil {
+        return false
+    }
 
-	return status
+    return status
 }
 
 // Delete the cached key from Redis storage
 func (r *Redis) Delete(key string) error {
-	return r.driver.Del(key).Err()
+    return r.driver.Del(key).Err()
 }
 
 // Retrieve the cached value from key of the Redis storage
 func (r *Redis) Fetch(key string) (string, error) {
-	value, err := r.driver.Get(key).Result()
+    value, err := r.driver.Get(key).Result()
 
-	if err != nil {
-		return "", err
-	}
+    if err != nil {
+        return "", err
+    }
 
-	return value, nil
+    return value, nil
 }
 
 // Retrieve multiple cached value from keys of the Redis storage
 func (r *Redis) FetchMulti(keys []string) map[string]string {
-	result := make(map[string]string)
+    result := make(map[string]string)
 
-	items, err := r.driver.MGet(keys...).Result()
+    items, err := r.driver.MGet(keys...).Result()
 
-	if err != nil {
-		return result
-	}
+    if err != nil {
+        return result
+    }
 
-	for i := 0; i < len(keys); i++ {
-		if items[i] != nil {
-			result[keys[i]] = items[i].(string)
-		}
-	}
+    for i := 0; i < len(keys); i++ {
+        if items[i] != nil {
+            result[keys[i]] = items[i].(string)
+        }
+    }
 
-	return result
+    return result
 }
 
 // Remove all cached keys in Redis storage
 func (r *Redis) Flush() error {
-	return r.driver.FlushAll().Err()
+    return r.driver.FlushAll().Err()
 }
 
 // Save a value in Redis storage by key
 func (r *Redis) Save(key string, value string, lifeTime time.Duration) error {
-	return r.driver.Set(key, value, lifeTime).Err()
+    return r.driver.Set(key, value, lifeTime).Err()
 }

--- a/redis_test.go
+++ b/redis_test.go
@@ -1,157 +1,155 @@
 package cachego
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
-	"gopkg.in/redis.v4"
-	"net"
-	"testing"
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/suite"
+    "gopkg.in/redis.v4"
+    "net"
+    "testing"
 )
 
 type RedisTestSuite struct {
-	suite.Suite
+    suite.Suite
 
-	assert *assert.Assertions
-	cache  Cache
+    assert *assert.Assertions
+    cache  Cache
 }
 
 func (s *RedisTestSuite) SetupTest() {
-	conn := redis.NewClient(&redis.Options{
-		Addr: ":6379",
-	})
+    conn := redis.NewClient(&redis.Options{
+        Addr: ":6379",
+    })
 
-	if _, err := net.Dial("tcp", "localhost:6379"); err != nil {
-		s.T().Skip()
-	}
+    if _, err := net.Dial("tcp", "localhost:6379"); err != nil {
+        s.T().Skip()
+    }
 
-	s.cache = &Redis{conn}
-	s.assert = assert.New(s.T())
+    s.cache = NewRedis(conn)
+    s.assert = assert.New(s.T())
 }
 
 func (s *RedisTestSuite) TestSaveThrowError() {
-	redis := redis.NewClient(&redis.Options{
-		Addr: ":6380",
-	})
+    redis := redis.NewClient(&redis.Options{
+        Addr: ":6380",
+    })
 
-	cache := &Redis{redis}
+    cache := NewRedis(redis)
 
-	s.assert.Error(cache.Save("foo", "bar", 0))
+    s.assert.Error(cache.Save("foo", "bar", 0))
 }
 
 func (s *RedisTestSuite) TestSave() {
-	s.assert.Nil(s.cache.Save("foo", "bar", 0))
+    s.assert.Nil(s.cache.Save("foo", "bar", 0))
 }
 
 func (s *RedisTestSuite) TestFetchThrowError() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	redis := redis.NewClient(&redis.Options{
-		Addr: ":6380",
-	})
+    redis := redis.NewClient(&redis.Options{
+        Addr: ":6380",
+    })
 
-	cache := &Redis{redis}
+    cache := NewRedis(redis)
 
-	result, err := cache.Fetch(key)
+    result, err := cache.Fetch(key)
 
-	s.assert.Error(err)
-	s.assert.Empty(result)
+    s.assert.Error(err)
+    s.assert.Empty(result)
 }
 
 func (s *RedisTestSuite) TestFetch() {
-	key := "foo"
-	value := "bar"
+    key := "foo"
+    value := "bar"
 
-	s.cache.Save(key, value, 0)
+    s.cache.Save(key, value, 0)
 
-	result, err := s.cache.Fetch(key)
+    result, err := s.cache.Fetch(key)
 
-	s.assert.Nil(err)
-	s.assert.Equal(value, result)
+    s.assert.Nil(err)
+    s.assert.Equal(value, result)
 }
 
 func (s *RedisTestSuite) TestContainsThrowError() {
-	redis := redis.NewClient(&redis.Options{
-		Addr: ":6380",
-	})
+    redis := redis.NewClient(&redis.Options{
+        Addr: ":6380",
+    })
 
-	cache := &Redis{redis}
+    cache := NewRedis(redis)
 
-	s.assert.False(cache.Contains("bar"))
+    s.assert.False(cache.Contains("bar"))
 }
 
 func (s *RedisTestSuite) TestContains() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.True(s.cache.Contains("foo"))
-	s.assert.False(s.cache.Contains("bar"))
+    s.assert.True(s.cache.Contains("foo"))
+    s.assert.False(s.cache.Contains("bar"))
 }
 
 func (s *RedisTestSuite) TestDeleteThrowError() {
-	redis := redis.NewClient(&redis.Options{
-		Addr: ":6380",
-	})
+    redis := redis.NewClient(&redis.Options{
+        Addr: ":6380",
+    })
 
-	cache := &Redis{redis}
-	s.assert.Error(cache.Delete("bar"))
+    cache := NewRedis(redis)
+    s.assert.Error(cache.Delete("bar"))
 }
 
 func (s *RedisTestSuite) TestDelete() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Delete("foo"))
-	s.assert.False(s.cache.Contains("foo"))
-	s.assert.Nil(s.cache.Delete("foo"))
+    s.assert.Nil(s.cache.Delete("foo"))
+    s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Delete("foo"))
 }
 
 func (s *RedisTestSuite) TestFlushThrowError() {
-	redis := redis.NewClient(&redis.Options{
-		Addr: ":6380",
-	})
+    redis := redis.NewClient(&redis.Options{
+        Addr: ":6380",
+    })
 
-	cache := &Redis{redis}
+    cache := NewRedis(redis)
 
-	s.assert.Error(cache.Flush())
+    s.assert.Error(cache.Flush())
 }
 
 func (s *RedisTestSuite) TestFlush() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	s.assert.Nil(s.cache.Flush())
-	s.assert.False(s.cache.Contains("foo"))
+    s.assert.Nil(s.cache.Flush())
+    s.assert.False(s.cache.Contains("foo"))
 }
 
 func (s *RedisTestSuite) TestFetchMultiReturnNoItemsWhenThrowError() {
-	cache := &Redis{
-		redis.NewClient(&redis.Options{
-			Addr: ":6380",
-		}),
-	}
+    cache := NewRedis(redis.NewClient(&redis.Options{
+        Addr: ":6380",
+    }))
 
-	result := cache.FetchMulti([]string{"foo"})
+    result := cache.FetchMulti([]string{"foo"})
 
-	s.assert.Len(result, 0)
+    s.assert.Len(result, 0)
 }
 
 func (s *RedisTestSuite) TestFetchMulti() {
-	s.cache.Save("foo", "bar", 0)
-	s.cache.Save("john", "doe", 0)
+    s.cache.Save("foo", "bar", 0)
+    s.cache.Save("john", "doe", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "john"})
+    result := s.cache.FetchMulti([]string{"foo", "john"})
 
-	s.assert.Len(result, 2)
+    s.assert.Len(result, 2)
 }
 
 func (s *RedisTestSuite) TestFetchMultiWhenOnlyOneOfKeysExists() {
-	s.cache.Save("foo", "bar", 0)
+    s.cache.Save("foo", "bar", 0)
 
-	result := s.cache.FetchMulti([]string{"foo", "alice"})
+    result := s.cache.FetchMulti([]string{"foo", "alice"})
 
-	s.assert.Len(result, 1)
+    s.assert.Len(result, 1)
 }
 
 func TestRedisRunSuite(t *testing.T) {
-	suite.Run(t, new(RedisTestSuite))
+    suite.Run(t, new(RedisTestSuite))
 }


### PR DESCRIPTION
I was receiving the following error when trying to use the Mongo cache (as documented):

`implicit assignment of unexported field 'collection' in cachego.Mongo literal`

For me, exporting Mongo.Collection fixed this issue.

Please note, this issue may affect other cache drivers as well, but I did not test those.